### PR TITLE
Add configuration to limit parallelism during XGBoost search

### DIFF
--- a/inlist
+++ b/inlist
@@ -12,3 +12,5 @@ val_size = 0.2
 random_state = 69
 output_dir = outputs/
 model_type = xgboost
+search_n_jobs = 1
+booster_n_jobs = 1

--- a/run.py
+++ b/run.py
@@ -34,6 +34,10 @@ def main():
     random_state = int(config['general']['random_state'])
     output_dir = config['general']['output_dir']
     model_type = config['general'].get('model_type', 'xgboost')  # Default to xgboost
+
+    # Control parallelism to avoid exhausting system resources during CV or model training
+    search_n_jobs = max(1, int(config['general'].get('search_n_jobs', '1')))
+    booster_n_jobs = max(1, int(config['general'].get('booster_n_jobs', str(max(1, os.cpu_count() or 1)))))
     
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
@@ -71,7 +75,8 @@ def main():
             objective='reg:squarederror',
             random_state=42,
             reg_alpha=0.1,
-            reg_lambda=1.0
+            reg_lambda=1.0,
+            n_jobs=booster_n_jobs
         )
         
         # Parameter distribution for RandomizedSearchCV
@@ -91,7 +96,7 @@ def main():
             cv=3,
             scoring='neg_mean_squared_error',
             verbose=1,
-            n_jobs=-1,
+            n_jobs=search_n_jobs,
             random_state=random_state
         )
         


### PR DESCRIPTION
## Summary
- allow configuring the number of workers used by RandomizedSearchCV and the XGBoost booster
- default to safe single-threaded execution to avoid resource exhaustion during cross validation
- extend the sample inlist with the new configuration options

## Testing
- python -m compileall run.py

------
https://chatgpt.com/codex/tasks/task_e_68e707133aec8321b0d7f71b1c8b5c3b