### PR TITLE
Add inference workflow for trained models

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -1,48 +1,85 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 from sklearn.model_selection import train_test_split
+
+FEATURE_COLUMNS = [
+    'GAL_LONG_sin', 'GAL_LONG_cos', 'GAL_LAT',
+    'Ks_mag', 'I1_mag', 'I2_mag', 'I3_mag', 'I4_mag', 'alpha',
+    'Ks_I1', 'I1_I2', 'I2_I3', 'I3_I4', 'I4_mag_sq'
+]
+
+TARGET_COLUMN = 'Mips_24_mag'
+
+
+def _add_engineered_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of *df* with all derived features required by the models."""
+
+    engineered = df.copy()
+
+    # Add derived features: color indices
+    engineered['Ks_I1'] = engineered['Ks_mag'] - engineered['I1_mag']
+    engineered['I1_I2'] = engineered['I1_mag'] - engineered['I2_mag']
+    engineered['I2_I3'] = engineered['I2_mag'] - engineered['I3_mag']
+    engineered['I3_I4'] = engineered['I3_mag'] - engineered['I4_mag']
+
+    # Cyclic encoding for GAL_LONG (replacing original GAL_LONG)
+    engineered['GAL_LONG_sin'] = np.sin(2 * np.pi * engineered['GAL_LONG'] / 360)
+    engineered['GAL_LONG_cos'] = np.cos(2 * np.pi * engineered['GAL_LONG'] / 360)
+
+    # Polynomial term for I4_mag (to help with non-linearity in faint sources)
+    engineered['I4_mag_sq'] = engineered['I4_mag'] ** 2
+
+    return engineered
+
 
 def load_and_split_data(data_file, test_size=0.2, val_size=0.2, random_state=42):
     """
     Loads the CSV data, preprocesses it, and splits into train/validation/test sets.
-    
+
     Assumes the CSV has columns: GAL_LONG, GAL_LAT, Ks_mag, I1_mag, I2_mag, I3_mag, I4_mag, Mips_24_mag, alpha.
     Features: All except Mips_24_mag (target).
     Handles missing values by dropping rows (if any; adjust as needed for prediction on missing targets).
     """
     df = pd.read_csv(data_file)
-    
-    # Add derived features: color indices
-    df['Ks_I1'] = df['Ks_mag'] - df['I1_mag']
-    df['I1_I2'] = df['I1_mag'] - df['I2_mag']
-    df['I2_I3'] = df['I2_mag'] - df['I3_mag']
-    df['I3_I4'] = df['I3_mag'] - df['I4_mag']
-    
-    # Cyclic encoding for GAL_LONG (replacing original GAL_LONG)
-    df['GAL_LONG_sin'] = np.sin(2 * np.pi * df['GAL_LONG'] / 360)
-    df['GAL_LONG_cos'] = np.cos(2 * np.pi * df['GAL_LONG'] / 360)
-    
-    # Polynomial term for I4_mag (to help with non-linearity in faint sources)
-    df['I4_mag_sq'] = df['I4_mag'] ** 2
-    
-    # Define updated features and target
-    features = [
-        'GAL_LONG_sin', 'GAL_LONG_cos', 'GAL_LAT', 
-        'Ks_mag', 'I1_mag', 'I2_mag', 'I3_mag', 'I4_mag', 'alpha',
-        'Ks_I1', 'I1_I2', 'I2_I3', 'I3_I4', 'I4_mag_sq'
-    ]
-    target = 'Mips_24_mag'
-    
+    df = _add_engineered_features(df)
+
+    if TARGET_COLUMN not in df.columns:
+        raise ValueError(f"Target column '{TARGET_COLUMN}' not found in the input data.")
+
     # Drop rows with missing target
-    df = df.dropna(subset=[target])
-    
-    X = df[features]
-    y = df[target]
-    
+    df = df.dropna(subset=[TARGET_COLUMN])
+
+    missing_features = [col for col in FEATURE_COLUMNS if col not in df.columns]
+    if missing_features:
+        raise ValueError(f"Missing required feature columns: {missing_features}")
+
+    X = df[FEATURE_COLUMNS]
+    y = df[TARGET_COLUMN]
+
     # Split into train+val and test
-    X_train_val, X_test, y_train_val, y_test = train_test_split(X, y, test_size=test_size, random_state=random_state)
-    
+    X_train_val, X_test, y_train_val, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state
+    )
+
     # Split train+val into train and val
-    X_train, X_val, y_train, y_val = train_test_split(X_train_val, y_train_val, test_size=val_size / (1 - test_size), random_state=random_state)
-    
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train_val, y_train_val,
+        test_size=val_size / (1 - test_size),
+        random_state=random_state
+    )
+
     return X_train, X_val, X_test, y_train, y_val, y_test
+
+
+def load_features_for_inference(data_file):
+    """Load data for inference and return the original dataframe along with model features."""
+
+    df = pd.read_csv(data_file)
+    df = _add_engineered_features(df)
+
+    missing_features = [col for col in FEATURE_COLUMNS if col not in df.columns]
+    if missing_features:
+        raise ValueError(f"Missing required feature columns for inference: {missing_features}")
+
+    feature_frame = df[FEATURE_COLUMNS]
+    return df, feature_frame

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,134 @@
+import argparse
+import configparser
+import os
+from typing import Optional
+
+from joblib import load
+
+from data_loader import FEATURE_COLUMNS, TARGET_COLUMN, load_features_for_inference
+
+
+def _read_config(path: str) -> configparser.ConfigParser:
+    """Safely read a configuration file, returning an empty parser if missing."""
+
+    parser = configparser.ConfigParser()
+    if os.path.exists(path):
+        parser.read(path)
+    return parser
+
+
+def _config_get(parser: configparser.ConfigParser, section: str, option: str, fallback=None):
+    if parser.has_option(section, option):
+        return parser.get(section, option)
+    return fallback
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run inference using a previously trained model.")
+    parser.add_argument(
+        "--config",
+        default="inlist",
+        help="Path to the configuration file used during training (default: inlist)."
+    )
+    parser.add_argument(
+        "--data-file",
+        dest="data_file",
+        help="CSV file containing sources to predict. If omitted, falls back to the training data file."
+    )
+    parser.add_argument(
+        "--model-path",
+        dest="model_path",
+        help="Path to the trained model weights. Defaults to <output_dir>/<model_type>_model.joblib."
+    )
+    parser.add_argument(
+        "--scaler-path",
+        dest="scaler_path",
+        help="Optional path to a fitted scaler (required for MLP models if not in the default location)."
+    )
+    parser.add_argument(
+        "--model-type",
+        dest="model_type",
+        choices=["xgboost", "ngboost", "mlp"],
+        help="Override the model type stored in the config file."
+    )
+    parser.add_argument(
+        "--output-file",
+        dest="output_file",
+        help="Where to save the predictions CSV. Defaults to <output_dir>/inference_results.csv."
+    )
+    parser.add_argument(
+        "--output-dir",
+        dest="output_dir",
+        help="Directory containing training artefacts. Defaults to the training output_dir."
+    )
+    return parser.parse_args()
+
+
+def _resolve_paths(args: argparse.Namespace, config: configparser.ConfigParser):
+    model_type = args.model_type or _config_get(config, 'general', 'model_type', fallback='xgboost')
+    output_dir = args.output_dir or _config_get(config, 'general', 'output_dir', fallback='outputs')
+    os.makedirs(output_dir, exist_ok=True)
+
+    model_path = args.model_path or os.path.join(output_dir, f"{model_type}_model.joblib")
+    scaler_path: Optional[str] = None
+    if model_type == 'mlp':
+        scaler_path = args.scaler_path or os.path.join(output_dir, f"{model_type}_scaler.joblib")
+
+    output_file = args.output_file or os.path.join(output_dir, 'inference_results.csv')
+
+    return model_type, output_dir, model_path, scaler_path, output_file
+
+
+def main():
+    args = parse_args()
+    config = _read_config(args.config)
+
+    data_file = args.data_file or _config_get(config, 'paths', 'data_file')
+    if data_file is None:
+        raise ValueError("No data file provided. Specify --data-file or define paths.data_file in the config.")
+
+    model_type, output_dir, model_path, scaler_path, output_file = _resolve_paths(args, config)
+
+    if not os.path.exists(model_path):
+        raise FileNotFoundError(f"Trained model not found at {model_path}. Run training or provide --model-path.")
+
+    if model_type == 'mlp':
+        if scaler_path is None or not os.path.exists(scaler_path):
+            raise FileNotFoundError(
+                "MLP models require a fitted scaler. Provide --scaler-path or ensure the default scaler exists."
+            )
+
+    original_df, feature_frame = load_features_for_inference(data_file)
+
+    model = load(model_path)
+
+    if model_type == 'mlp':
+        scaler = load(scaler_path)
+        transformed_features = scaler.transform(feature_frame)
+        predictions = model.predict(transformed_features)
+        results_df = original_df.copy()
+        results_df[f"{TARGET_COLUMN}_pred"] = predictions
+    elif model_type == 'ngboost':
+        pred_dist = model.pred_dist(feature_frame)
+        predictions = pred_dist.loc
+        std_devs = pred_dist.scale
+        results_df = original_df.copy()
+        results_df[f"{TARGET_COLUMN}_pred"] = predictions
+        results_df[f"{TARGET_COLUMN}_pred_std"] = std_devs
+    else:  # xgboost
+        predictions = model.predict(feature_frame)
+        results_df = original_df.copy()
+        results_df[f"{TARGET_COLUMN}_pred"] = predictions
+
+    # Keep only original columns plus predictions to avoid duplicating engineered features unless desired
+    base_columns = [col for col in original_df.columns if col not in FEATURE_COLUMNS or col == TARGET_COLUMN]
+    export_columns = base_columns + [col for col in results_df.columns if col not in original_df.columns]
+    export_df = results_df[export_columns]
+
+    export_df.to_csv(output_file, index=False)
+
+    print(f"Inference complete. Saved predictions for {len(export_df)} sources to {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -1,10 +1,13 @@
 import configparser
 import os
+
+from joblib import dump
+
 from data_loader import load_and_split_data
 from posterior import generate_posterior  # Import the new function
 import numpy as np
 from sklearn.model_selection import train_test_split, RandomizedSearchCV
-import pandas as pd 
+import pandas as pd
 
 from plots import (
     plot_actual_vs_predicted, 
@@ -122,6 +125,17 @@ def main():
     else:
         raise ValueError(f"Unsupported model_type: {model_type}.")
     
+    # Persist trained artefacts for later inference
+    model_path = os.path.join(output_dir, f"{model_type}_model.joblib")
+    dump(model, model_path)
+    print(f"Saved trained {model_type} model to {model_path}")
+
+    scaler_path = None
+    if scaler is not None:
+        scaler_path = os.path.join(output_dir, f"{model_type}_scaler.joblib")
+        dump(scaler, scaler_path)
+        print(f"Saved feature scaler to {scaler_path}")
+
     # Generate plots
     plot_actual_vs_predicted(y_test, predictions, os.path.join(output_dir, 'actual_vs_predicted.png'))
     plot_feature_importance(


### PR DESCRIPTION
## Summary
- refactor data preprocessing to expose reusable feature engineering helpers
- persist trained models and scalers for reuse during inference
- add an inference CLI to load saved weights and synthesize missing photometry

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ff8c8a06908321b0b070dd92af3fdb